### PR TITLE
Fix email assignment syntax

### DIFF
--- a/assistants/crt/c.yaml
+++ b/assistants/crt/c.yaml
@@ -57,9 +57,9 @@ run:
     - $clname~: $(python -c 'import pwd,posix; print pwd.getpwuid(posix.getuid()).pw_gecos')
   - $clemail~: $(git config user.email)
   - if not $clemail:
-    - $clemail1~: $(id -un)
-    - $clemail2~: $(uname -n)
-    - $clemail~: "$clemail1@$clemail1"
+    - $user~: $(id -un)
+    - $host~: $(uname -n)
+    - $clemail~: $(echo "$user@$host")
   - cl: sed -i "s|Fri Mar 15 2013 UserName <user@host>|$cldate $clname <$clemail>|" "$basename.spec"
   - use: git.init_add_commit.run
 - else:


### PR DESCRIPTION
1. Yaml treats "$clemail1@$clemail1" not as a string literal and fails
   tokenizing '@'. Use 'echo' to make sure it is a string. Fixes crash on
   project creation:
   https://github.com/devassistant/devassistant/issues/376
2. We want to have email be set to "$user@$host", not a "$user@$user"
   (which "$clemail1@$clemail1" represents). Give meaningful names to these
   variables.
